### PR TITLE
Modified fastDecodeResponseMessage to decode correctly data returned if more than 3 registers (of type R) was read

### DIFF
--- a/lib/GE_SRTP.py
+++ b/lib/GE_SRTP.py
@@ -26,13 +26,16 @@ class GeSrtpResponse:
         self.status_code_minor = 0
         self.debug_logging = debug_logging
 
-        self.fastDecodeResponseMessage(response)
+        self.fastDecodeResponseMessage(response, num_registers)
 
 
 
-    def fastDecodeResponseMessage(self, msg):
+    def fastDecodeResponseMessage(self, msg, num_registers=1):
         try:
-            start_byte = 44
+            if num_registers <= 3:
+                start_byte = 44
+            else:
+                start_byte = 56
             end_byte = start_byte + (2 * self.num_registers)
             self.status_code         = struct.unpack('B', bytes([msg[42]]))[0]
             self.status_code_minor   = struct.unpack('B', bytes([msg[43]]))[0]


### PR DESCRIPTION
If more than 3 registers (type R) was read, data from plc does not start at byte 44, but at byte 56.

When I read 3 registers (in red rectangle there are data)

![immagine](https://github.com/user-attachments/assets/2d904ddc-9659-482f-8a95-72a47c56a365)

When I read 5 registers (in red rectangle there are data)

![immagine](https://github.com/user-attachments/assets/fd92a43b-12b3-4003-83a4-97a3257ef4cc)

I haven't tried this modification with other type of data, only with R.